### PR TITLE
docs(changelog): record the classifier v1 removal and the missing 2.16.0 feature line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 ## [2.16.0](https://github.com/run-llama/llama-parse-py/compare/v2.15.0...v2.16.0) (2026-09-08)
 
 
+### ⚠ BREAKING CHANGES
+
+* **classifier:** the classify v1 job methods (`client.classifier.jobs.create`, `.list`, `.get`, `.get_results`) are removed. The `/api/v1/classifier/jobs*` routes were unpublished from the API surface; use `client.classify` instead.
+
 ### Features
 
 * **api:** add paginated GET /api/v2/pipelines, deprecate the v1 list ([#25587](https://github.com/run-llama/llama-parse-py/issues/25587)) ([5570f91](https://github.com/run-llama/llama-parse-py/commit/5570f91b7053e54650e44ead7132c72efa797922))
+* **api:** map DELETE /api/v2/parse/{job_id} and GET /api/v2/pipelines into the SDKs (LI-9569) ([4f8b659](https://github.com/run-llama/llama-parse-py/commit/4f8b6596993b93bd156c78bfd0a1826a16f819a5))
 * **api:** return what Parse `latest` resolves to on GET /api/v2/parse/versions ([#25824](https://github.com/run-llama/llama-parse-py/issues/25824)) ([404907f](https://github.com/run-llama/llama-parse-py/commit/404907f388951a860d9466fe81519258c3cf4f64))
 * **llamaparse:** agentic 2026-09-07 — heading rules: own-line titles, furniture, document-wide levels ([#26146](https://github.com/run-llama/llama-parse-py/issues/26146)) ([ca98a0d](https://github.com/run-llama/llama-parse-py/commit/ca98a0d15a3c37cd57f9656a95f6572d668f4e51))
 * **split:** expose custom_instructions on the public Split API ([#25680](https://github.com/run-llama/llama-parse-py/issues/25680)) ([13d1063](https://github.com/run-llama/llama-parse-py/commit/13d106397e669c409edff1784625729a69765b9b))


### PR DESCRIPTION
Corrects the **already-shipped** 2.16.0 changelog. CHANGELOG.md only — no code, no version bump, nothing to release. Edits stay inside the existing 2.16.0 section, which release-please preserves (it prepends new sections).

## What changed

**Records a breaking change that shipped unannounced.** 2.16.0 removed `client.classifier.jobs.create`, `.list`, `.get` and `.get_results` — the `/api/v1/classifier/jobs*` routes were unpublished from the API surface (platform#25682), so the whole `client.classifier` namespace is gone from the client at 2.16.0 while it existed at 2.15.0. Users upgrading lose those methods with no notice. `client.classify` (v2) is the replacement and is unchanged. This is the second such silent drop — 2.15.0 removed the Sheets and Verify endpoints the same way.

**Restores the release's headline feature line.** 2.16.0 mapped `DELETE /api/v2/parse/{job_id}` and `GET /api/v2/pipelines` into the SDKs (LI-9569), and the five sibling SDKs list it. Python does not: its build went through `stlc-resolve-conflicts`, whose `stlc build --continue --push` commits as the literal subject `Build SDK`, which is not a conventional commit, so release-please dropped it. The restored line points at 4f8b659 — the commit that actually added `parsing_delete_params.py`, `parsing_delete_response.py`, `pipeline_list_paginated_params.py` and the corresponding resource methods.

## Why

The published changelog is what a user reads before upgrading. Missing the feature makes the release look emptier than it was; missing the removal makes it look safe when it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMu5B12QEd4JXFVXZUUS8f